### PR TITLE
chore: update `github_user_name`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: Platane/snk@master
         id: snake-gif
         with:
-          github_user_name: joaogabrielvlf
+          github_user_name: jgvlf
           svg_out_path: dist/github-contribution-grid-snake.svg
 
       - uses: crazy-max/ghaction-github-pages@v2.1.3


### PR DESCRIPTION
Changed  `github_user_name` to our new profile name, i think this is the right answer.